### PR TITLE
Added description about the order of `signatureHelp` and `didChange`

### DIFF
--- a/_specifications/lsp/3.18/language/signatureHelp.md
+++ b/_specifications/lsp/3.18/language/signatureHelp.md
@@ -2,6 +2,8 @@
 
 The signature help request is sent from the client to the server to request signature information at a given cursor position.
 
+If a user types and the client decides to ask for signature help, `textDocument/didChange` event must be delivered to the server before the signature help request is sent.
+
 _Client Capability_:
 * property name (optional): `textDocument.signatureHelp`
 * property type: `SignatureHelpClientCapabilities` defined as follows:


### PR DESCRIPTION
Copy this [discussion](https://github.com/microsoft/language-server-protocol/issues/2011#issuecomment-2343081904) to the document.

This content could help language server developers to safely handle signature help requests after the compilation and I think the compilation is usually triggered by `didChange` event.